### PR TITLE
Fix : User can update their profile

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,2 @@
+DATABASE_URL="mongodb://localhost/argentBankDB"
+SECRET_KEY=your-secret-key

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ node_modules
 config/runtime.yaml
 
 .DS_Store
+
+# Environment variables
+.env

--- a/frontend/src/pages/Dashboard/index.jsx
+++ b/frontend/src/pages/Dashboard/index.jsx
@@ -1,44 +1,100 @@
 // src/pages/Dashboard/index.jsx
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { fetchUserThunk } from "../../redux/thunks/userProfileThunk";
+import { fetchUserThunk, updateUserThunk } from "../../redux/thunks/userProfileThunk";
 import "../Dashboard/index.scss";
 import Header from "../../components/Header";
 import Footer from "../../components/Footer";
 
 function Dashboard() {
-  // Utilisation du hook useSelector pour récupérer le prénom de l'utilisateur depuis le store Redux.
+  // Récupération du prénom de l'utilisateur depuis le store Redux.
   const userFirstName = useSelector((state) => state.userProfile.firstName);
-  // Utilisation du hook useSelector pour récupérer le nom de l'utilisateur depuis le store Redux.
+  // Récupération du nom de l'utilisateur depuis le store Redux.
   const userLastName = useSelector((state) => state.userProfile.lastName);
-  // Utilisation du hook useDispatch pour dispatcher des actions Redux.
+  // Hook pour dispatcher des actions Redux.
   const dispatch = useDispatch();
-  // Utilisation du hook useSelector pour récupérer le token d'authentification depuis le store Redux.
+  // Récupération du token d'authentification depuis le store Redux.
   const userToken = useSelector((state) => state.auth.token);
+  // État pour contrôler l'affichage du formulaire d'édition.
+  const [editView, setEditView] = useState(false);
+  // État pour stocker le prénom saisi dans le formulaire d'édition.
+  const [firstName, setFirstName] = useState(userFirstName);
+  // État pour stocker le nom saisi dans le formulaire d'édition.
+  const [lastName, setLastName] = useState(userLastName);
 
-  // Effet de bord React qui s'exécute après chaque rendu.
-  // Il récupère les données du profil utilisateur si un token est présent.
+  // Effet qui se déclenche après chaque rendu et récupère les données du profil utilisateur.
   useEffect(() => {
-    // Condition pour vérifier si un token d'authentification est disponible.
+    // Si un token d'authentification est présent...
     if (userToken) {
-      // Dispatch de l'action asynchrone fetchUserThunk pour récupérer les données du profil.
-      // Le token est passé en argument pour l'authentification de la requête API.
+      // ...on déclenche le thunk pour récupérer les informations du profil.
       dispatch(fetchUserThunk(userToken));
     }
-    // Tableau de dépendances pour useEffect.  L'effet ne se déclenchera que si userToken ou dispatch changent.
+    // L'effet ne se déclenche que si userToken ou dispatch changent.
   }, [userToken, dispatch]);
+
+  // Fonction qui affiche le formulaire d'édition.
+  const updateProfile = async () => {
+    setEditView(true);
+  };
+
+  // Fonction qui gère la sauvegarde des modifications du profil.
+  const handleSave = async () => {
+    // Envoi de la requête pour mettre à jour le profil via le thunk updateUserThunk
+    dispatch(updateUserThunk({ token: userToken, firstName, lastName }));
+    // Masque le formulaire après la sauvegarde
+    setEditView(false);
+  };
+
+  // Fonction qui annule les modifications et ferme le formulaire.
+  const handleCancel = () => {
+    // Réinitialise les valeurs des champs de formulaire à celles récupérées depuis le store
+    setFirstName(userFirstName);
+    setLastName(userLastName);
+    // Masque le formulaire
+    setEditView(false);
+  };
 
   return (
     <>
       <Header />
       <main className="main bg-dark">
-        <div className="header">
-          <h1>
-            Welcome back
-            <br />
-            {userFirstName} {userLastName}
-          </h1>
-        </div>
+        {!editView ? (
+          <div className="header">
+            <h1>
+              Welcome back
+              <br />
+              {userFirstName} {userLastName}
+            </h1>
+            <button className='edit-button' onClick={updateProfile}>
+              Edit Name
+            </button>
+          </div>
+        ) : (
+          <div className='header'>
+            <h1>Welcome back</h1>
+            <div className='edit-form'>
+              <input
+                type='text'
+                onChange={(e) => setFirstName(e.target.value)}
+                placeholder={userFirstName}
+              />
+              <input
+                type='text'
+                onChange={(e) => setLastName(e.target.value)}
+                placeholder={userLastName}
+              />
+              <div className='edit-buttons'>
+                <button className='cancel-button' onClick={handleCancel}>
+                  Cancel
+                </button>
+                <button className='save-button' onClick={handleSave}>
+                  Save
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
         <h2 className="sr-only">Accounts</h2>
         <section className="account">
           <div className="account-content-wrapper">

--- a/frontend/src/redux/services/apiService.js
+++ b/frontend/src/redux/services/apiService.js
@@ -57,7 +57,8 @@ export const updateUserProfile = async (token, firstName, lastName) => {
 
   // Vérification de la réponse de l'API
   if (!response.ok) {
-    throw new Error(`Erreur lors de la mise à jour du profil. Veuillez réessayer plus tard.`);
+    const errorData = await response.json().catch(() => ({ message: `Erreur HTTP : ${response.status}` }));
+    throw new Error(errorData.message);
   }
   
   // Convertit la réponse de l'API en JSON

--- a/frontend/src/redux/slices/userProfileSlice.js
+++ b/frontend/src/redux/slices/userProfileSlice.js
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { fetchUserThunk } from '../thunks/userProfileThunk';
+import { fetchUserThunk, updateUserThunk } from '../thunks/userProfileThunk';
 
 // État initial du slice de profil utilisateur.
 // firstName et lastName : contiennent les informations du prénom et du nom de l'utilisateur (null initialement).
@@ -34,6 +34,23 @@ const userProfileSlice = createSlice({
       })
       .addCase(fetchUserThunk.rejected, (state, action) => {
         // Lorsque le thunk fetchUserThunk échoue
+        state.status = 'failed';
+        state.error = action.error.message; // Récupérer le message d'erreur
+      })
+      .addCase(updateUserThunk.pending, (state) => {
+        // Lorsque le thunk updateUserThunk commence
+        state.status = 'loading';
+        state.error = null; // Réinitialisation de l'erreur
+      })
+      .addCase(updateUserThunk.fulfilled, (state, action) => {
+        // Lorsque le thunk updateUserThunk réussit
+        state.status = 'succeeded';
+        state.firstName = action.payload.body.firstName;
+        state.lastName = action.payload.body.lastName;
+        state.error = null;
+      })
+      .addCase(updateUserThunk.rejected, (state, action) => {
+        // Lorsque le thunk updateUserThunk échoue
         state.status = 'failed';
         state.error = action.error.message; // Récupérer le message d'erreur
       });

--- a/frontend/src/redux/thunks/userProfileThunk.js
+++ b/frontend/src/redux/thunks/userProfileThunk.js
@@ -1,4 +1,4 @@
-import { fetchUserProfile } from '../services/apiService';
+import { fetchUserProfile, updateUserProfile } from '../services/apiService';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
 // Action asynchrone pour récupérer le profil de l'utilisateur
@@ -7,6 +7,19 @@ export const fetchUserThunk = createAsyncThunk(
   async (token, { rejectWithValue }) => {
     try {
       const responseData = await fetchUserProfile(token);
+      return responseData;
+    } catch (error) {
+      return rejectWithValue(error.message);
+    }
+  },
+);
+
+// Action asynchrone pour mettre à jour le profil de l'utilisateur
+export const updateUserThunk = createAsyncThunk(
+  'userProfile/updateProfile',
+  async ({ token, firstName, lastName }, { rejectWithValue }) => {
+    try {
+      const responseData = await updateUserProfile(token, firstName, lastName);
       return responseData;
     } catch (error) {
       return rejectWithValue(error.message);


### PR DESCRIPTION
This PR implements the profile editing feature, addressing the remaining part of issue #6:

- Added `extraReducers` to the `userProfile` slice to handle the different states of `updateUserThunk` (pending, fulfilled, rejected).
- Improved error handling in `apiService.js` to provide more informative error messages.
- Implemented the `updateUserThunk` to handle updating user profile data on the backend.
- Added the profile editing functionality to the Dashboard component, including the form, state management, and save/cancel logic.
- Added a `.gitignore` entry for `.env` and created an `env.template` file.

Note:  The state management with Redux was progressively integrated throughout previous features (the specific Redux setup was not a separate feature).

This PR closes issue #6.